### PR TITLE
tilerator: disable 'debug' stream in logging configuration

### DIFF
--- a/tilerator/config.api.yaml
+++ b/tilerator/config.api.yaml
@@ -12,8 +12,6 @@ worker_heartbeat_timeout: '{env(TILERATOR_WORKER_HEARTBEAT_TIMEOUT,7500)}'
 # Logger info
 logging:
   level: info
-  streams:
-    - type: debug
 #  streams:
 #  # Use gelf-stream -> logstash
 #  - type: gelf

--- a/tilerator/config.worker.yaml
+++ b/tilerator/config.worker.yaml
@@ -12,8 +12,6 @@ worker_heartbeat_timeout: '{env(TILERATOR_WORKER_HEARTBEAT_TIMEOUT,30000)}'
 # Logger info
 logging:
   level: info
-  streams:
-    - type: debug
 #  streams:
 #  # Use gelf-stream -> logstash
 #  - type: gelf


### PR DESCRIPTION
This debug stream depends on an optional dependency (`'bunyan-prettystream'`), that is no longer installed. 
And it's not suitable for production anyway (https://github.com/hadfieldn/node-bunyan-prettystream#readme).