### PR TITLE
kartotherian: Define more environment variables for configuration

### DIFF
--- a/kartotherian/Dockerfile
+++ b/kartotherian/Dockerfile
@@ -18,8 +18,14 @@ RUN git clone https://github.com/Qwant/kartotherian.git /opt/kartotherian \
 COPY kartotherian/config.yaml /etc/kartotherian
 COPY kartotherian/sources.yaml /etc/kartotherian
 
+ENV KARTOTHERIAN_PORT=6533
 ENV KARTOTHERIAN_CASSANDRA_SERVERS=cassandra
 ENV KARTOTHERIAN_CASSANDRA_USER=gis
 ENV KARTOTHERIAN_CASSANDRA_PSWD=
+
+# Set KARTOTHERIAN_TELEGRAF_HOST to empty string to disable stats metrics reporter
+ENV KARTOTHERIAN_TELEGRAF_HOST=telegraf
+ENV KARTOTHERIAN_TELEGRAF_PORT=8125
+
 
 CMD node /opt/kartotherian/packages/kartotherian/server.js -c /etc/kartotherian/config.yaml

--- a/kartotherian/config.yaml
+++ b/kartotherian/config.yaml
@@ -16,15 +16,15 @@ logging:
 metrics:
   name: kartotherian
   type: debug
-  host: telegraf
-  port: 8125
+  host: '{env(KARTOTHERIAN_TELEGRAF_HOST,)}'
+  port: '{env(KARTOTHERIAN_TELEGRAF_PORT,8125)}'
 
 services:
   - name: kartotherian
     module: kartotherian
 
     conf:
-      port: 6533
+      port: '{env(KARTOTHERIAN_PORT, 6533)}'
       cors: '{env(KARTOTHERIAN_CORS_ORIGIN,*)}'
 
       # Comment this out to allow connections from everywhere


### PR DESCRIPTION
Some values used to be hardcoded in "kartotherian/config.yaml"
New environment variables for Kartotherian to make the configuration easier:
* `KARTOTHERIAN_PORT`:  default 6533
* `KARTOTHERIAN_TELEGRAF_HOST`: host used to connect to Telegraf (where statsd metrics will be sent).
These metrics will be disabled if this variable is empty.
* `KARTOTHERIAN_TELEGRAF_PORT`: default 8125