### PR TITLE
load_db: Ensure that latest openssl and libssl versions are installed

### DIFF
--- a/load_db/Dockerfile
+++ b/load_db/Dockerfile
@@ -3,6 +3,7 @@ FROM python:3.6-stretch
 ENV MAIN_DIR=/srv/import_data
 
 RUN apt-get update && \
+    apt-get upgrade -y openssl && \
     apt-get install -y --no-install-recommends \
         git \
         unzip \


### PR DESCRIPTION
The new image will include `libssl1.0.2 >= 1.0.2u-1~deb9u6`

Required to connect to https://planet.osm.org now that [DST Root CA X3](https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021/) has expired.