### PR TITLE
update docker images to debian bullseye

### DIFF
--- a/kartotherian/Dockerfile
+++ b/kartotherian/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-stretch
+FROM node:14-bullseye
 
 ENV NODE_ENV=production
 

--- a/kartotherian/Dockerfile
+++ b/kartotherian/Dockerfile
@@ -13,7 +13,7 @@ USER node
 RUN git clone https://github.com/Qwant/kartotherian.git /opt/kartotherian \
     && cd /opt/kartotherian \
     && git checkout 46dedb6d0c46d0f1dbf6ad4e029d676c63fc5eab \
-    && npm ci --production
+    && npm ci --production --python=python3
 
 COPY kartotherian/config.yaml /etc/kartotherian
 COPY kartotherian/sources.yaml /etc/kartotherian

--- a/load_db/Dockerfile
+++ b/load_db/Dockerfile
@@ -1,9 +1,8 @@
-FROM python:3.6-stretch
+FROM python:3.6-bullseye
 
 ENV MAIN_DIR=/srv
 
 RUN apt-get update && \
-    apt-get upgrade -y openssl && \
     apt-get install -y --no-install-recommends \
         git \
         unzip \

--- a/tilerator/Dockerfile
+++ b/tilerator/Dockerfile
@@ -14,7 +14,6 @@ RUN apt-get update && \
         nmap \
         netcat \
         redis-tools \
-        python3.5 \
         python3-pip \
         locales \
     && npm i npm@latest -g
@@ -22,11 +21,11 @@ RUN apt-get update && \
 RUN git clone https://github.com/Qwant/kartotherian.git /opt/kartotherian \
     && cd /opt/kartotherian \
     && git checkout 46dedb6d0c46d0f1dbf6ad4e029d676c63fc5eab \
-    && npm ci --production
+    && npm ci --production --python=python3
 
 # install openmaptiles-tools
-RUN python3.5 -m pip install --upgrade pip \
-    && python3.5 -m pip install openmaptiles-tools==0.9.2
+RUN python3 -m pip install --upgrade pip \
+    && python3 -m pip install openmaptiles-tools==0.9.2
 # install openmaptiles
 COPY openmaptiles /opt/openmaptiles
 # setup needed directories

--- a/tilerator/Dockerfile
+++ b/tilerator/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-stretch
+FROM node:14-bullseye
 
 ENV NODE_ENV=production
 


### PR DESCRIPTION
Debian stretch has reach the [LTS state](https://wiki.debian.org/LTS) until June 2022.