### PR TITLE
Qmaps-2322 upgrade debian  (to buster) and python  (to 3.6) version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
-
-      - name: Set env variables
+  
+      - name: Extract branch name
+        if: github.event_name != 'pull_request'
         run: |
           REF=${GITHUB_REF#refs/*/}
           if [ "$REF" == "master" ]; then
@@ -47,6 +48,18 @@ jobs:
             # Replace '/' with '__'
             IMAGE_TAG=${REF//\//__}
           fi
+          echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
+      - name: Extract branch name
+        if: github.event_name == 'pull_request'
+        run: |
+          echo "IMAGE_TAG=$GITHUB_HEAD_REF" >> $GITHUB_ENV
+
+      # extract branch name on pull request
+      - name: Print branch name
+        run: echo "${IMAGE_TAG}"
+        
+      - name: Set env variables
+        run: |
           echo "DOCKER_IMAGE=${DOCKER_IMAGE_PREFIX}_$SERVICE:$IMAGE_TAG" >> $GITHUB_ENV
           echo "SERVICE=$SERVICE" >> $GITHUB_ENV
         env:
@@ -63,6 +76,6 @@ jobs:
           docker build --label "org.label-schema.vcs-ref=$GITHUB_SHA" -t $DOCKER_IMAGE -f ./$SERVICE/Dockerfile .
 
       - name: Docker push
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || github.event_name == 'pull_request'
         run: |
           docker push $DOCKER_IMAGE

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,9 @@ services:
       dockerfile: load_db/Dockerfile
     read_only: true
     environment:
-      - INVOKE_CONFIG_FILE=config.yml
+      - INVOKE_GENERATED_FILES_DIR=/data/generated
+      - INVOKE_DATA_DIR=/data/input
+      - INVOKE_UPDATE_TILES_DIR=/data/update_tiles_data
     tmpfs:
       - /tmp
     volumes:

--- a/import_data/tasks/tasks.py
+++ b/import_data/tasks/tasks.py
@@ -461,6 +461,26 @@ def override_wikidata_weight_functions(ctx):
     _run_sql_script(ctx, "import-wikidata/wikidata_functions.sql", template_params=params)
 
 
+@task
+def run_post_sql_scripts_base(ctx):
+    """
+    load the sql file with all the functions to generate the layers
+    this file has been generated using https://github.com/Qwant/openmaptiles
+    """
+    logging.info("running postsql scripts")
+    _run_sql_script(ctx, "generated_base.sql")
+
+
+@task
+def run_post_sql_scripts_poi(ctx):
+    """
+    load the sql file with all the functions to generate the layers
+    this file has been generated using https://github.com/Qwant/openmaptiles
+    """
+    logging.info("running postsql scripts")
+    _run_sql_script(ctx, "generated_poi.sql")
+
+
 # import pipeline
 ###################
 @task

--- a/kartotherian/Dockerfile
+++ b/kartotherian/Dockerfile
@@ -1,4 +1,9 @@
-FROM node:14-stretch
+FROM node:14-buster-slim
+
+RUN apt-get update \
+        && DEBIAN_FRONTEND=noninteractive apt-get install --assume-yes --quiet --no-install-recommends \
+            git python3.6 build-essential \
+        && apt-get clean
 
 ENV NODE_ENV=production
 

--- a/load_db/import_data.sh
+++ b/load_db/import_data.sh
@@ -5,4 +5,8 @@ set -x
 optional_invoke_args=$@
 
 # run the python script that loads all the data
-invoke -f $INVOKE_CONFIG_FILE $optional_invoke_args
+if [[ -z "${INVOKE_CONFIG_FILE}" ]]; then
+  invoke $optional_invoke_args
+else
+  invoke -f $INVOKE_CONFIG_FILE $optional_invoke_args
+fi

--- a/tilerator/Dockerfile
+++ b/tilerator/Dockerfile
@@ -1,9 +1,7 @@
-FROM node:14-stretch
-
-ENV NODE_ENV=production
+FROM node:14-buster-slim
 
 RUN apt-get update && \
-    apt-get install -y \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
         git \
         unzip \
         curl \
@@ -14,9 +12,11 @@ RUN apt-get update && \
         nmap \
         netcat \
         redis-tools \
-        python3.5 \
         python3-pip \
         locales \
+        python3.6 \
+        build-essential \
+    && apt-get clean \
     && npm i npm@latest -g
 
 RUN git clone https://github.com/Qwant/kartotherian.git /opt/kartotherian \
@@ -25,8 +25,9 @@ RUN git clone https://github.com/Qwant/kartotherian.git /opt/kartotherian \
     && npm ci --production
 
 # install openmaptiles-tools
-RUN python3.5 -m pip install --upgrade pip \
-    && python3.5 -m pip install openmaptiles-tools==0.9.2
+RUN python3 -m pip install --upgrade pip \
+    && python3 -m pip install git+https://github.com/openmaptiles/openmaptiles-tools@v0.12.0
+    
 # install openmaptiles
 COPY openmaptiles /opt/openmaptiles
 # setup needed directories


### PR DESCRIPTION
allow using entrypoint without config file (use invoke.yaml as fallback allow to override via env var)
push images also for branches with open PR
upgrade debian version to buster
uniformize the python version >3.6 as needed by nodejs build process 