### PR TITLE
imposm: run without the -quiet parameter

### DIFF
--- a/import_data/tasks/osm_update.py
+++ b/import_data/tasks/osm_update.py
@@ -49,7 +49,7 @@ def run_imposm_update(ctx, tileset, change_file, pg_connection):
 
     try:
         ctx.run(
-            f'imposm3 diff -quiet \
+            f'imposm3 diff \
                 -connection {pg_connection} \
                 -mapping {mapping_path} \
                 -cachedir {path.join(ctx.generated_files_dir, "cache", imposm_folder_name)} \

--- a/import_data/tasks/tasks.py
+++ b/import_data/tasks/tasks.py
@@ -216,7 +216,7 @@ def get_osm_data(ctx):
 
 def _run_imposm_import(ctx, tileset_config):
     ctx.run(
-        "time imposm3 import -write -diff -quiet -deployproduction -overwritecache"
+        "time imposm3 import -write -diff -deployproduction -overwritecache"
         f' {"-optimize" if ctx.imposm.optimize else ""}'
         f' --connection "{_pg_conn_str(ctx, ctx.pg.import_database)}"'
         f" -read {ctx.osm.file}"


### PR DESCRIPTION
The schedules in plive are currently crashing (exit code 0) with no
output, hopefully removing the -quiet parameter that we pass to imposm
will help having more detail.